### PR TITLE
Added @stub directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ src/editor/main.js
 src/editor/main.js.map
 src/editor/main.css
 src/editor/main.css.map
+
+# IntelliJ stuff
+.idea

--- a/src/default-schema.graphql
+++ b/src/default-schema.graphql
@@ -13,7 +13,7 @@
 
 type Company {
   id: ID
-  name: String @fake(type: companyName)
+  name: String @stub(value: "Stubbed Name")
   industry: String
     @examples(values: ["IT", "Manufacturing", "Medicine", "Media"])
   employees: [Employee!] @listLength(min: 5, max: 10)

--- a/src/fake_definition.ts
+++ b/src/fake_definition.ts
@@ -220,6 +220,9 @@ const fakeDefinitionAST = parse(/* GraphQL */ `
 
   scalar examples__JSON
   directive @examples(values: [examples__JSON]!) on FIELD_DEFINITION | SCALAR
+
+  scalar stub__JSON
+  directive @stub(value: stub__JSON!) on FIELD_DEFINITION | SCALAR
 `);
 
 function defToName(defNode) {

--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -31,7 +31,7 @@ type ExamplesArgs = {
   values: [any];
 };
 type StubArgs = {
-  value: [any];
+  value: any;
 };
 type ListLengthArgs = {
   min: number;


### PR DESCRIPTION
Added a `@stub` directive that lets you define a stub to always use in the mocked response. This avoids random data, as well as repeated data (`@example` randomly picks from a list of example data which can result in the same values being used)

Works with built-in types as well as custom ones, example:

```
type CustomType {
  name: String
  id: Int
}

type Example {
   field: String @stub(value: "Hello world")
   field2: [CustomType!] @stub(value: [{ name: "Hello", id: 1 }, { name: "World", id: 2 }])
}
```